### PR TITLE
Fix user deletion when user not found

### DIFF
--- a/src/main/java/com/example/service/UserService.java
+++ b/src/main/java/com/example/service/UserService.java
@@ -35,6 +35,9 @@ public class UserService {
     }
     
     public void deleteUser(Long id) {
+        if (!userRepository.existsById(id)) {
+            throw new UserNotFoundException("User not found with id " + id);
+        }
         userRepository.deleteById(id);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.h2.console.enabled=true
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- update datasource property to use correct format
- throw `UserNotFoundException` when deleting nonexistent user

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846547b8af88320b867e30268cfaee3