### PR TITLE
Fix user existence check before deletion

### DIFF
--- a/src/main/java/com/example/service/UserService.java
+++ b/src/main/java/com/example/service/UserService.java
@@ -35,9 +35,9 @@ public class UserService {
     }
     
     public void deleteUser(Long id) {
-        if (!userRepository.existsById(id)) {
-            throw new UserNotFoundException("User not found with id " + id);
-        }
+        // Reuse getUserById to ensure the user exists and throw the
+        // appropriate exception when not found.
+        getUserById(id);
         userRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## Summary
- ensure `deleteUser` invokes `getUserById` before deleting

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684656294344832080396537444a48a1